### PR TITLE
Support multiple URIs wihtout a prefix in the Context.

### DIFF
--- a/kotlin-wot-reflection/src/main/kotlin/reflection/ExposedThingBuilder.kt
+++ b/kotlin-wot-reflection/src/main/kotlin/reflection/ExposedThingBuilder.kt
@@ -73,10 +73,10 @@ object ExposedThingBuilder {
                 title = thingAnnotation.title
                 objectType = Type(thingAnnotation.type)
                 val contexts = clazz.findAnnotations<Context>()
-                if(contexts.isNotEmpty()){
+                if (contexts.isNotEmpty()) {
                     val context = org.eclipse.thingweb.thing.schema.Context(DEFAULT_CONTEXT)
                     contexts.forEach {
-                        context.addContext(it.prefix, it.url)
+                        if (it.prefix.isEmpty()) context.addContext(it.url) else context.addContext(it.prefix, it.url)
                     }
                     objectContext = context
                 }

--- a/kotlin-wot-reflection/src/main/kotlin/reflection/annotations/Annotations.kt
+++ b/kotlin-wot-reflection/src/main/kotlin/reflection/annotations/Annotations.kt
@@ -15,7 +15,7 @@ annotation class Thing(val id: String, val title: String, val description: Strin
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 @Repeatable
-annotation class Context(val prefix: String, val url : String)
+annotation class Context(val prefix: String = "", val url : String)
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)

--- a/kotlin-wot/src/main/kotlin/thing/ContextSerializer.kt
+++ b/kotlin-wot/src/main/kotlin/thing/ContextSerializer.kt
@@ -23,20 +23,20 @@ internal class ContextSerializer : JsonSerializer<Context>() {
         gen: JsonGenerator,
         serializers: SerializerProvider
     ) {
-        val defaultUrl: String? = context.defaultUrl
+        val defaultUrls: List<String> = context.defaultUrls
         val prefixedUrls: Map<String, String> = context.prefixedUrls
-        val hasDefaultUrl = defaultUrl != null
+        val hasDefaultUrls = defaultUrls.isNotEmpty()
         val hasPrefixedUrls = prefixedUrls.isNotEmpty()
-        if (hasDefaultUrl && hasPrefixedUrls) {
+        if (hasDefaultUrls && hasPrefixedUrls) {
             gen.writeStartArray()
         }
-        if (hasDefaultUrl) {
-            gen.writeString(defaultUrl)
+        defaultUrls.forEach {
+            gen.writeString(it)
         }
         if (hasPrefixedUrls) {
             gen.writeObject(prefixedUrls)
         }
-        if (hasDefaultUrl && hasPrefixedUrls) {
+        if (hasDefaultUrls && hasPrefixedUrls) {
             gen.writeEndArray()
         }
     }

--- a/kotlin-wot/src/main/kotlin/thing/ThingDescription.kt
+++ b/kotlin-wot/src/main/kotlin/thing/ThingDescription.kt
@@ -126,25 +126,6 @@ data class ThingDescription @JsonCreator constructor(
         securityDefinitions[name] = securityScheme
     }
 
-    fun getPropertiesByObjectType(objectType: String): Map<String, PropertyAffordance<*>> {
-        return getPropertiesByExpandedObjectType(getExpandedObjectType(objectType))
-    }
-
-    private fun getPropertiesByExpandedObjectType(objectType: String): Map<String, PropertyAffordance<*>> {
-        return properties.filter { (_, property) ->
-            property.objectType?.defaultType?.let { getExpandedObjectType(it) } == objectType
-        }.toMap()
-    }
-
-    fun getExpandedObjectType(objectType: String): String {
-
-        val parts = objectType.split(":", limit = 2)
-        val prefix = if (parts.size == 2) parts[0] else null
-        val suffix = parts.last()
-
-        return objectContext?.getUrl(prefix)?.let { "$it#$suffix" } ?: objectType
-    }
-
     fun toJson() : String{
         return try {
             JsonMapper.instance.writeValueAsString(this)

--- a/kotlin-wot/src/main/kotlin/thing/schema/Context.kt
+++ b/kotlin-wot/src/main/kotlin/thing/schema/Context.kt
@@ -16,35 +16,28 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
  */
 @JsonDeserialize(using = ContextDeserializer::class)
 @JsonSerialize(using = ContextSerializer::class)
-//@Serializable(with = ContextSerializer::class)
-data class Context(private val urls: MutableMap<String?, String> = HashMap()) {
+data class Context(val defaultUrls: MutableList<String> = mutableListOf(), private val prefixeUrls: MutableMap<String, String> = HashMap()) {
 
     constructor(url: String) : this() {
         addContext(url)
     }
 
-    constructor(prefix: String?, url: String) : this() {
+    constructor(prefix: String, url: String) : this() {
         addContext(prefix, url)
     }
 
     fun addContext(url: String): Context {
-        return addContext(null, url)
-    }
-
-    fun getUrl(prefix: String?): String? {
-        return urls[prefix]
-    }
-
-    fun addContext(prefix: String?, url: String): Context {
-        urls[prefix] = url
+        defaultUrls.add(url)
         return this
     }
 
-    val defaultUrl: String?
-        get() = urls[null] // Directly accessing the map
+    fun addContext(prefix: String, url: String): Context {
+        prefixeUrls[prefix] = url
+        return this
+    }
 
     val prefixedUrls: Map<String, String>
-        get() = urls.entries
+        get() = prefixeUrls.entries
             .filter { (key, _) -> key != null }
             .associate { (key, value) -> key!! to value }
 }


### PR DESCRIPTION
If you want to define [Thing Description Directories](https://www.w3.org/TR/wot-discovery/#directory-api-spec), you need to add the URI https://www.w3.org/2022/wot/discovery without a prefix to the Context. However, this is currently not possible.

E.g.

```
"@context" : [ 
    "https://www.w3.org/2022/wot/td/v1.1", 
    "https://www.w3.org/2022/wot/discovery", 
    { "lmos" : "https://eclipse.dev/lmos/protocol/v1"} 
] 
```